### PR TITLE
Update the bedroom lights to make more sense.

### DIFF
--- a/esphome/bedroom.yaml
+++ b/esphome/bedroom.yaml
@@ -47,22 +47,22 @@ binary_sensor:
       mode: INPUT_PULLUP
       inverted: True
     name: "Bedroom ceiling touchpad"
-    on_press:
-      - then:
-        - switch.toggle: ceiling_relay
   - platform: status
     name: "Bedroom gang status"
 
 switch:
-  # Relay 1-2 unused
-  #- platform: gpio
-  #  pin: GPIO12
-  #- platform: gpio
-  #  pin: GPIO5
   - platform: gpio
-    id: ceiling_relay
-    name: "Bedroom ceiling"
+    name: "Andrea gang led"
+    pin: GPIO12
+    restore_mode: RESTORE_DEFAULT_ON
+  - platform: gpio
+    name: "Marta gang led"
+    pin: GPIO5
+    restore_mode: RESTORE_DEFAULT_ON
+  - platform: gpio
+    name: "Bedroom ceiling relay"
     pin: GPIO4
+    restore_mode: RESTORE_DEFAULT_ON
 
 output:
   # Register the blue LED as a dimmable output ....

--- a/homeassistant/automations.yaml
+++ b/homeassistant/automations.yaml
@@ -1,5 +1,5 @@
 - id: '1600897077572'
-  alias: 'Andrea light: turn on when switch is pressed'
+  alias: 'Andrea light: toggle when switch is pressed'
   description: ''
   trigger:
   - platform: mqtt
@@ -13,7 +13,7 @@
     domain: light
   mode: single
 - id: '1600897936269'
-  alias: 'Marta light: turn on when switch is pressed'
+  alias: 'Marta light: toggle when switch is pressed'
   description: ''
   trigger:
   - platform: mqtt
@@ -26,93 +26,16 @@
     entity_id: light.marta
     domain: light
   mode: single
-- id: '1600898255154'
-  alias: 'Andrea switch light: turn off when Andrea light goes off'
+- id: '1601215489574'
+  alias: 'Bedroom ceiling light: toggle when switch is pressed'
   description: ''
   trigger:
-  - platform: state
-    entity_id: light.andrea
-    from: 'on'
-    to: 'off'
+  - platform: mqtt
+    topic: bedroom/binary_sensor/bedroom_ceiling_touchpad/state
+    payload: 'ON'
   condition: []
   action:
-  - service: mqtt.publish
-    data:
-      topic: bedroom/switch/andrea_light/command
-      payload: 'OFF'
-  mode: single
-- id: '1600899972543'
-  alias: 'Andrea switch light: turn on when Andrea light goes on'
-  description: ''
-  trigger:
-  - platform: state
-    entity_id: light.andrea
-    from: 'off'
-    to: 'on'
-  condition: []
-  action:
-  - service: mqtt.publish
-    data:
-      topic: bedroom/switch/andrea_light/command
-      payload: 'ON'
-  mode: single
-- id: '1601021835492'
-  alias: 'Marta switch light: turn on when Marta light goes on'
-  description: ''
-  trigger:
-  - platform: state
-    entity_id: light.marta
-    from: 'off'
-    to: 'on'
-  condition: []
-  action:
-  - service: mqtt.publish
-    data:
-      topic: bedroom/switch/marta_light/command
-      payload: 'ON'
-  mode: single
-- id: '1601021887611'
-  alias: 'Marta switch light: turn off when Marta light goes off'
-  description: ''
-  trigger:
-  - platform: state
-    entity_id: light.marta
-    from: 'on'
-    to: 'off'
-  condition: []
-  action:
-  - service: mqtt.publish
-    data:
-      topic: bedroom/switch/marta_light/command
-      payload: 'OFF'
-  mode: single
-- id: '1601022116689'
-  alias: 'Bedroom ceiling switch light: turn on when Bedroom light goes on'
-  description: ''
-  trigger:
-  - platform: state
-    entity_id: light.bedroom
-    from: 'off'
-    to: 'on'
-  condition: []
-  action:
-  - service: mqtt.publish
-    data:
-      topic: bedroom/switch/bedroom_ceiling/command
-      payload: 'ON'
-  mode: single
-- id: '1601022149132'
-  alias: 'Bedroom ceiling switch light: turn off when Bedroom light goes off'
-  description: ''
-  trigger:
-  - platform: state
-    entity_id: light.bedroom
-    from: 'on'
-    to: 'off'
-  condition: []
-  action:
-  - service: mqtt.publish
-    data:
-      topic: bedroom/switch/bedroom_ceiling/command
-      payload: 'OFF'
+  - service: light.toggle
+    data: {}
+    entity_id: light.bedroom_ceiling
   mode: single

--- a/homeassistant/configuration.yaml
+++ b/homeassistant/configuration.yaml
@@ -56,3 +56,12 @@ sensor:
       - Hackney
       - Islington
       - Tower Hamlets
+
+light:
+  - platform: group
+    name: Bedroom Ceiling
+    entities:
+      - light.bedroom_near_andrea
+      - light.bedroom_near_closet
+      - light.bedroom_near_marta
+      - light.bedroom_near_window


### PR DESCRIPTION
At a high level, leave the power to the ceiling lights on full time.
We still want to configure the relays, but leave them on; treating them as relays rather than leds.

Set up a group for ceiling lights so we can more clearly manipulate them as a group (and not touch the "all bedroom lights" which would touch night stand lights too).

Remove unnecessary or even harmful automation.